### PR TITLE
Fix documentation link to point to ActiveLRS Github Pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,4 +10,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Generator for plain Ruby model classes from xAPI profiles.
 - Auto-generated RSpec test files for each model.
 - Ability to fetch xAPI statements matching events defined in an xAPI profile.
-- Basic documentation ([view docs](https://www.rubydoc.info/github/RaceRocks/activelrs)).
+- Basic documentation ([view docs](https://racerocks.github.io/activelrs)).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ to admin@racerocks3d.com.
 
 ## I Have a Question
 
-> If you want to ask a question, we assume that you have read the available [Documentation](https://rubydoc.info/github/RaceRocks/activelrs).
+> If you want to ask a question, we assume that you have read the available [Documentation](https://racerocks.github.io/activelrs).
 
 Before you ask a question, it is best to search for existing [Issues](https://github.com/RaceRocks/activelrs/issues) that might help you. In case you have found a suitable issue and still need clarification, you can write your question in this issue. It is also advisable to search the internet for answers first.
 
@@ -63,7 +63,7 @@ We will then take care of the issue as soon as possible.
 A good bug report shouldn't leave others needing to chase you up for more information. Therefore, we ask you to investigate carefully, collect information and describe the issue in detail in your report. Please complete the following steps in advance to help us fix any potential bug as fast as possible.
 
 - Make sure that you are using the latest version.
-- Determine if your bug is really a bug and not an error on your side e.g. using incompatible environment components/versions (Make sure that you have read the [documentation](https://rubydoc.info/github/RaceRocks/activelrs). If you are looking for support, you might want to check [this section](#i-have-a-question)).
+- Determine if your bug is really a bug and not an error on your side e.g. using incompatible environment components/versions (Make sure that you have read the [documentation](https://racerocks.github.io/activelrs). If you are looking for support, you might want to check [this section](#i-have-a-question)).
 - To see if other users have experienced (and potentially already solved) the same issue you are having, check if there is not already a bug report existing for your bug or error in the [bug tracker](https://github.com/RaceRocks/activelrs/issues?q=label%3Abug).
 - Also make sure to search the internet (including Stack Overflow) to see if users outside of the GitHub community have discussed the issue.
 - Collect information about the bug:
@@ -100,7 +100,7 @@ This section guides you through submitting an enhancement suggestion for ActiveL
 #### Before Submitting an Enhancement
 
 - Make sure that you are using the latest version.
-- Read the [documentation](https://rubydoc.info/github/RaceRocks/activelrs) carefully and find out if the functionality is already covered, maybe by an individual configuration.
+- Read the [documentation](https://racerocks.github.io/activelrs) carefully and find out if the functionality is already covered, maybe by an individual configuration.
 - Perform a [search](https://github.com/RaceRocks/activelrs/issues) to see if the enhancement has already been suggested. If it has, add a comment to the existing issue instead of opening a new one.
 - Find out whether your idea fits with the scope and aims of the project. It's up to you to make a strong case to convince the project's developers of the merits of this feature. Keep in mind that we want features that will be useful to the majority of our users and not just a small subset. If you're just targeting a minority of users, consider writing an add-on/plugin library.
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,11 @@ This generator will fetch an xAPI profile from the [xAPI profile server API](htt
 > [!TIP]
 > You can find xAPI profiles and their IRIs [here](https://profiles.adlnet.gov/profiles).
 
+## Documentation
+
+For a full list of available functionality, usage details, and examples, please check out the [documentation](https://racerocks.github.io/activelrs).  
+This is the best place to explore all classes, modules, and methods provided by the library.
+
 ## Development
 
 ### 1. Clone the repository
@@ -91,7 +96,6 @@ Build gem
 ```bash
 gem build active_lrs.gemspec
 ```
-
 
 ## Testing and Quality Assurance
 
@@ -117,7 +121,7 @@ bundle exec rubocop path/to/file.rb
 bundle exec rubocop -A
 ```
 
-## ## Attribution
+## Attribution
 
 This project includes code derived from [Xapi](https://github.com/Deakin-Prime/Xapi), 
 licensed under MIT. We have modified it for our use case.


### PR DESCRIPTION
## Description
Updated the documentation link to point to ActiveLRS GitHub Pages instead of relying on rubydoc.info for reliability reason.
The link now directs users to: https://racerocks.github.io/activelrs

## Related Issue(s)
N/A

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [x] Documentation update
- [ ] Refactor / Code improvement

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/RaceRocks/activelrs/blob/main/CONTRIBUTING.md) and followed the guidelines
- [ ] Tests added / updated (if applicable)
- [x] Documentation updated (if applicable)
- [ ] Linting / CI passes

## Additional Notes
N/A
