### PR TITLE
Make LRS version configurable per instance

### DIFF
--- a/lib/active_lrs/client.rb
+++ b/lib/active_lrs/client.rb
@@ -29,6 +29,9 @@ module ActiveLrs
     # @return [String] The attribute path for pagination (e.g., "more" or "pagination.more")
     attr_reader :more_attribute
 
+    # @return [String] The xAPI version to use
+    attr_reader :version
+
     # @return [Faraday::Connection] The Faraday connection instance
     attr_reader :connection
 
@@ -41,14 +44,16 @@ module ActiveLrs
     # @param username [String] Username for Basic Authentication
     # @param password [String] Password for Basic Authentication
     # @param more_attribute [String] Attribute path for pagination URL (defaults to "more")
+    # @param version [String] The xAPI version (defaults to "2.0.0")
     # @param options [Hash] Optional Faraday connection options
     #
     # @return [void]
-    def initialize(url:, username:, password:, more_attribute: "more", options: {})
+    def initialize(url:, username:, password:, more_attribute: "more", version: "2.0.0", options: {})
       @base_url = url
       @username = username
       @password = password
       @more_attribute = more_attribute
+      @version = version
       @connection = build_connection(options)
     end
 
@@ -58,7 +63,7 @@ module ActiveLrs
     # @return [Faraday::Connection] Configured Faraday connection
     def build_connection(options)
       Faraday.new(url: base_url, **options) do |conn|
-        conn.headers["X-Experience-API-Version"] = "2.0.0"
+        conn.headers["X-Experience-API-Version"] = version
         conn.response :json
         conn.request :authorization, :basic, username, password
         conn.adapter Faraday.default_adapter

--- a/lib/active_lrs/statement.rb
+++ b/lib/active_lrs/statement.rb
@@ -58,7 +58,8 @@ module ActiveLrs
           url: lrs["url"],
           username: lrs["username"],
           password: lrs["password"],
-          more_attribute: lrs["more_attribute"] || "more"
+          more_attribute: lrs["more_attribute"] || "more",
+          version: lrs["version"] || "2.0.0"
         )
 
         statements.concat(self::VERBS.values.flat_map do |iri|

--- a/lib/generators/active_lrs/install/templates/remote_lrs.yml
+++ b/lib/generators/active_lrs/install/templates/remote_lrs.yml
@@ -5,11 +5,13 @@ development:
       username: dev_user
       password: secret
       more_attribute: more
+      version: 2.0.0
     - name: lrs2
       url: https://dev2.example.com/xapi
       username: dev_user
       password: secret
       more_attribute: pagination.more
+      version: 1.2.0
 
 production:
   endpoints:
@@ -18,3 +20,4 @@ production:
       username: prod_user
       password: prod_secret
       more_attribute: more
+      version: 2.0.0


### PR DESCRIPTION
## Summary
Adds configurable xAPI version support to enable compatibility with different Learning Record Store (LRS) versions. Each LRS instance can now specify its own version in the configuration.

## Changes
- **Updated `remote_lrs.yml` template**: Added `version` field with example values (2.0.0, 1.2.0)
- **Modified `Client` class**: 
  - Added `version` parameter to `initialize` (defaults to "2.0.0")
  - Added `version` attr_reader
  - Updated `build_connection` to use configured version in `X-Experience-API-Version` header
- **Updated `Statement.fetch`**: Passes version from config to Client constructor with "2.0.0" fallback

## Example Configuration
```yaml
development:
  endpoints:
    - name: lrs1
      url: https://dev1.example.com/xapi
      username: dev_user
      password: secret
      version: 2.0.0
    - name: lrs2
      url: https://dev2.example.com/xapi
      username: dev_user
      password: secret
      version: 1.2.0
```

## Backwards Compatibility
- Version defaults to "2.0.0" if not specified in config
- Existing configurations without version will continue to work

## Testing
- ✅ Ruby syntax validated
- ✅ Backwards compatible (default version "2.0.0")
- ✅ Follows existing code patterns and documentation style

Closes #6