### PR TITLE
FLC-251 Update Logic for Count and Distinct Restrictions

### DIFF
--- a/lib/active_lrs/statement.rb
+++ b/lib/active_lrs/statement.rb
@@ -527,11 +527,7 @@ module ActiveLrs
     # @param attribute [String, Symbol] the attribute to check for presence
     # @return [Array<ActiveLrs::Xapi::Statement>] a filtered array of xAPI statements
     def apply_attribute_filter(statements, attribute = @count)
-      statements.each_with_object([]) do |statement, selected_statements|
-        current_value = dig_via_methods(statement, attribute)
-        next if current_value.nil?
-        selected_statements << statement
-      end
+      Array(statements).select { |s| !dig_via_methods(s, attribute).nil? }
     end
 
     # Helper to filter statements within an array based on distinct values of a specific attribute.
@@ -540,13 +536,11 @@ module ActiveLrs
     # @param attribute [String, Symbol] the attribute to check for distinctness
     # @return [Array<ActiveLrs::Xapi::Statement>] a filtered array of xAPI statements
     def apply_distinct_filter(statements, attribute = @count)
-      seen = {}
-      statements.each_with_object([]) do |statement, selected_statements|
-        current_value = dig_via_methods(statement, attribute)
-        next if current_value.nil? || seen.key?(current_value)
-        seen[current_value] = true
-        selected_statements << statement
-      end
+      Array(statements)
+      .map { |s| [ s, dig_via_methods(s, attribute) ] }
+      .select { |_, value| !value.nil? }
+      .map(&:first)
+      .uniq { |s| dig_via_methods(s, attribute) }
     end
     # @!endgroup
   end

--- a/lib/active_lrs/statement.rb
+++ b/lib/active_lrs/statement.rb
@@ -519,22 +519,6 @@ module ActiveLrs
       end
     end
 
-    # Helper to filter statements within an array based on distinct-counting rules.
-    # Only the first occurrence of each unique @count value is kept if @distinct is true, returns all if false.
-    #
-    # @param statements [Array<ActiveLrs::Xapi::Statement>] an array of xAPI statements
-    # @return [Array<ActiveLrs::Xapi::Statement>] a filtered array of xAPI statements
-    def filter_statements_to_count(statements)
-      seen = {}
-      statements.each_with_object([]) do |statement, selected_statements|
-        current_value = dig_via_methods(statement, @count)
-        next if current_value.nil?
-        next if @distinct && seen.key?(current_value)
-        seen[current_value] = true
-        selected_statements << statement
-      end
-    end
-
     # Helper to filter statements within an array based on the presence of a specific attribute.
     #
     # @param statements [Array<ActiveLrs::Xapi::Statement>] an array of xAPI statements

--- a/lib/active_lrs/statement.rb
+++ b/lib/active_lrs/statement.rb
@@ -216,7 +216,7 @@ module ActiveLrs
 
     # Counts statements, optionally applying a field to count.
     #
-    # @param field [String, Symbol, nil] Field to count (optional). Defaults to :id.
+    # @param field [String, Symbol, nil] Field to count (optional). Defaults to :id
     # @return [Integer, Hash] Returns an integer if no grouping is applied, or a hash if grouped
     def count(field = :id)
       @count = field
@@ -488,7 +488,7 @@ module ActiveLrs
       count != 0 ? (total / count) : nil
     end
 
-    # Groups an array of xAPI statements by the @group_by key, also selects distinct statements if @select and @distinct are specified.
+    # Groups an array of xAPI statements by the @group_by key, also filters statements before performing aggregation.
     #
     # @param statements [Array<ActiveLrs::Xapi::Statement>] the array of xAPI statements to group
     # @return [Hash] a hash with group keys mapping to arrays of statements
@@ -503,7 +503,7 @@ module ActiveLrs
       end
 
       # Apply distinct filtering within each group
-      results = apply_count_filters(results) unless @distinct.nil?
+      results = apply_count_filters(results)
       results
     end
 

--- a/lib/active_lrs/statement.rb
+++ b/lib/active_lrs/statement.rb
@@ -226,7 +226,9 @@ module ActiveLrs
       if @group_by.nil? && @distinct.nil? && @count == :id
         results.size
       elsif @group_by.nil?
-        filter_statements_to_count(results).size
+        results = apply_attribute_filter(results) if @count
+        results = apply_distinct_filter(results) if @distinct
+        results.size
       else
         apply_group_count(results)
       end

--- a/lib/active_lrs/statement.rb
+++ b/lib/active_lrs/statement.rb
@@ -223,7 +223,7 @@ module ActiveLrs
 
       results = to_a
 
-      if @group_by.nil? && @distinct.nil?
+      if @group_by.nil? && @distinct.nil? && @count == :id
         results.size
       elsif @group_by.nil?
         filter_statements_to_count(results).size

--- a/lib/active_lrs/statement.rb
+++ b/lib/active_lrs/statement.rb
@@ -458,7 +458,10 @@ module ActiveLrs
     def apply_aggregate(statements)
       grouped_results = apply_group(statements)
 
-      results = grouped_results.transform_values do |group_statements|
+      # Apply filtering to each group of statements
+      filtered_grouped_results = apply_statement_filters(grouped_results)
+
+      results = filtered_grouped_results.transform_values do |group_statements|
         yield(group_statements)
       end
 
@@ -501,9 +504,6 @@ module ActiveLrs
         key = format_group_by_timestamp(key, @period) if (@group_by.to_s == "timestamp") && @period
         results[key] << statement
       end
-
-      # Apply distinct filtering within each group
-      results = apply_count_filters(results)
       results
     end
 
@@ -511,7 +511,7 @@ module ActiveLrs
     #
     # @param statement_hash [Hash<String, Array<ActiveLrs::Xapi::Statement>>] the hash of grouped xAPI statements
     # @return [Hash] the same hash structure but with filtered xAPI statements
-    def apply_count_filters(statement_hash)
+    def apply_statement_filters(statement_hash)
       statement_hash.transform_values { |statements| filter_statements_to_count(statements) }
     end
 

--- a/lib/active_lrs/statement.rb
+++ b/lib/active_lrs/statement.rb
@@ -214,7 +214,7 @@ module ActiveLrs
       self
     end
 
-    # Counts statements, optionally applying a field to count. 
+    # Counts statements, optionally applying a field to count.
     # If a field is provided, only statements where that field is not nil are counted.
     #
     # @param field [String, Symbol, nil] Field to count (optional). Defaults to :id
@@ -528,7 +528,7 @@ module ActiveLrs
     # @param attribute [String, Symbol] the attribute to check for presence
     # @return [Array<ActiveLrs::Xapi::Statement>] a filtered array of xAPI statements
     def apply_present_filter(statements, attribute = @count)
-      Array(statements).select { |s| !dig_via_methods(s, attribute).nil? }
+      Array(statements).select { |s| !dig_via_methods(s, attribute.to_s).nil? }
     end
 
     # Helper to filter statements within an array based on distinct values of a specific attribute.
@@ -538,10 +538,8 @@ module ActiveLrs
     # @return [Array<ActiveLrs::Xapi::Statement>] a filtered array of xAPI statements
     def apply_distinct_filter(statements, attribute = @count)
       Array(statements)
-      .map { |s| [ s, dig_via_methods(s, attribute) ] }
-      .select { |_, value| !value.nil? }
-      .map(&:first)
-      .uniq { |s| dig_via_methods(s, attribute) }
+                      .reject { |s| dig_via_methods(s, attribute.to_s).nil? }
+                      .uniq { |s| dig_via_methods(s, attribute.to_s) }
     end
     # @!endgroup
   end

--- a/lib/active_lrs/statement.rb
+++ b/lib/active_lrs/statement.rb
@@ -119,9 +119,9 @@ module ActiveLrs
 
     # Shortcut for 'count' on a new instance.
     #
-    # @param field [String] Field to count (optional)
+    # @param field [String, Symbol, nil] Field to count (optional). Defaults to :id
     # @return [Integer, Hash]
-    def self.count(field = nil)
+    def self.count(field = :id)
       new.count(field)
     end
 
@@ -216,10 +216,10 @@ module ActiveLrs
 
     # Counts statements, optionally applying a field to count.
     #
-    # @param field [String] Field to count (optional)
+    # @param field [String, Symbol, nil] Field to count (optional). Defaults to :id.
     # @return [Integer, Hash] Returns an integer if no grouping is applied, or a hash if grouped
-    def count(field = nil)
-      @count = field || "id"
+    def count(field = :id)
+      @count = field
 
       results = to_a
 
@@ -252,7 +252,7 @@ module ActiveLrs
       self
     end
 
-    # Specifies count must count distinct statements based on a specified field.
+    # Enables distinct counting when performing `count`
     def distinct
       @distinct = true
       self

--- a/lib/active_lrs/statement.rb
+++ b/lib/active_lrs/statement.rb
@@ -493,7 +493,7 @@ module ActiveLrs
       count != 0 ? (total / count) : nil
     end
 
-    # Groups an array of xAPI statements by the @group_by key, also filters statements before performing aggregation.
+    # Groups an array of xAPI statements by the @group_by key. 
     #
     # @param statements [Array<ActiveLrs::Xapi::Statement>] the array of xAPI statements to group
     # @return [Hash] a hash with group keys mapping to arrays of statements

--- a/lib/active_lrs/statement.rb
+++ b/lib/active_lrs/statement.rb
@@ -214,7 +214,8 @@ module ActiveLrs
       self
     end
 
-    # Counts statements, optionally applying a field to count.
+    # Counts statements, optionally applying a field to count. 
+    # If a field is provided, only statements where that field is not nil are counted.
     #
     # @param field [String, Symbol, nil] Field to count (optional). Defaults to :id
     # @return [Integer, Hash] Returns an integer if no grouping is applied, or a hash if grouped

--- a/lib/active_lrs/statement.rb
+++ b/lib/active_lrs/statement.rb
@@ -226,7 +226,7 @@ module ActiveLrs
       if @group_by.nil? && @distinct.nil? && @count == :id
         results.size
       elsif @group_by.nil?
-        results = apply_attribute_filter(results) if @count
+        results = apply_present_filter(results) if @count
         results = apply_distinct_filter(results) if @distinct
         results.size
       else
@@ -493,7 +493,7 @@ module ActiveLrs
       count != 0 ? (total / count) : nil
     end
 
-    # Groups an array of xAPI statements by the @group_by key. 
+    # Groups an array of xAPI statements by the @group_by key.
     #
     # @param statements [Array<ActiveLrs::Xapi::Statement>] the array of xAPI statements to group
     # @return [Hash] a hash with group keys mapping to arrays of statements
@@ -515,7 +515,7 @@ module ActiveLrs
     # @return [Hash] the same hash structure but with filtered xAPI statements
     def apply_statement_filters(statement_hash)
       statement_hash.transform_values do |statements|
-        filtered_statements = apply_attribute_filter(statements)
+        filtered_statements = apply_present_filter(statements)
         filtered_statements = apply_distinct_filter(statements) if @distinct
         filtered_statements
       end
@@ -526,7 +526,7 @@ module ActiveLrs
     # @param statements [Array<ActiveLrs::Xapi::Statement>] an array of xAPI statements
     # @param attribute [String, Symbol] the attribute to check for presence
     # @return [Array<ActiveLrs::Xapi::Statement>] a filtered array of xAPI statements
-    def apply_attribute_filter(statements, attribute = @count)
+    def apply_present_filter(statements, attribute = @count)
       Array(statements).select { |s| !dig_via_methods(s, attribute).nil? }
     end
 

--- a/spec/statement_spec.rb
+++ b/spec/statement_spec.rb
@@ -280,58 +280,24 @@ RSpec.describe ActiveLrs::Statement do
           })
         end
 
-        # TODO: Cut this later
-        it "counts verb IDs from grouped statements" do
-          results = ActiveLrs::Statement.group("object.id").count("verb.id")
-          puts("counts verb IDs from grouped statements: #{results.inspect}")
-          expect(results).to eq({
-            "http://example.org/courses/math101" => 4,
-            "http://example.org/courses/science201" => 2
-          })
-        end
-
         it "counts distinct verb IDs from grouped statements" do
           results = ActiveLrs::Statement.group("object.id").distinct.count("verb.id")
-          puts("counts distinct verb IDs from grouped statements: #{results.inspect}")
           expect(results).to eq({
             "http://example.org/courses/math101" => 3,
             "http://example.org/courses/science201" => 2
           })
         end
 
-        # TODO: Cut this later
-        it "counts distinct actor names from grouped statements" do
-          results = ActiveLrs::Statement.group("object.id").count("actor.name")
-          puts("counts actor names from grouped statements: #{results.inspect}")
-          expect(results).to eq({
-            "http://example.org/courses/math101" => 4,
-            "http://example.org/courses/science201" => 2
-          })
-        end
-
         it "counts distinct actor names from grouped statements" do
           results = ActiveLrs::Statement.group("object.id").distinct.count("actor.name")
-          puts("counts distinct actor names from grouped statements: #{results.inspect}")
           expect(results).to eq({
             "http://example.org/courses/math101" => 2,
             "http://example.org/courses/science201" => 2
           })
         end
 
-        # TODO: Cut this later
-        it "counts actor names from day-based grouped statements" do
-          results = ActiveLrs::Statement.group("timestamp", period: :day).count("actor.name")
-          puts("counts actor names from day-based grouped statements: #{results.inspect}")
-          expect(results).to eq({
-            "2025-01-01" => 3,
-            "2025-01-02" => 2,
-            "2025-01-03" => 1
-          })
-        end
-
         it "counts distinct actor names from day-based grouped statements" do
           results = ActiveLrs::Statement.group("timestamp", period: :day).distinct.count("actor.name")
-          puts("counts distinct actor names from day-based grouped statements: #{results.inspect}")
           expect(results).to eq({
             "2025-01-01" => 2,
             "2025-01-02" => 2,
@@ -339,35 +305,15 @@ RSpec.describe ActiveLrs::Statement do
           })
         end
 
-        # TODO: Cut this later
-        it "counts actor names from week-based grouped statements" do
-          results = ActiveLrs::Statement.group("timestamp", period: :week).count("actor.name")
-          puts("counts actor names from week-based grouped statements: #{results.inspect}")
-          expect(results).to eq({
-            "2025-W01" => 6
-          })
-        end
-
         it "counts distinct actor names from week-based grouped statements" do
           results = ActiveLrs::Statement.group("timestamp", period: :week).distinct.count("actor.name")
-          puts("counts distinct actor names from week-based grouped statements: #{results.inspect}")
           expect(results).to eq({
             "2025-W01" => 3
           })
         end
 
-        # TODO: Cut this later
-        it "counts actor names from month-based grouped statements" do
-          results = ActiveLrs::Statement.group("timestamp", period: :month).count("actor.name")
-          puts("counts actor names from month-based grouped statements: #{results.inspect}")
-          expect(results).to eq({
-            "2025-01" => 6
-          })
-        end
-
         it "counts distinct actor names from month-based grouped statements" do
           results = ActiveLrs::Statement.group("timestamp", period: :month).distinct.count("actor.name")
-          puts("counts distinct actor names from month-based grouped statements: #{results.inspect}")
           expect(results).to eq({
             "2025-01" => 3
           })

--- a/spec/statement_spec.rb
+++ b/spec/statement_spec.rb
@@ -104,6 +104,25 @@ RSpec.describe ActiveLrs::Statement do
         expect(results).to eq(6)
       end
 
+      it "counts all distinct statements" do
+        results = ActiveLrs::Statement.distinct.count
+        expect(results).to eq(6)
+      end
+
+      it "counts a specified field" do
+        results = ActiveLrs::Statement.count("actor.name")
+        expect(results).to eq(6)
+      end
+
+      it "counts distinct values in a specified field" do
+        results = ActiveLrs::Statement.distinct.count("actor.name")
+        expect(results).to eq(3)
+      end
+
+      it "returns 0 if the specified field does not exist" do
+        results = ActiveLrs::Statement.count("nonexistent.field")
+      end
+
       it "counts simple queries" do
         results = ActiveLrs::Statement.where("actor.name": "Alice").count
         expect(results).to eq(3)
@@ -114,16 +133,6 @@ RSpec.describe ActiveLrs::Statement do
                                       .since("2025-01-01T10:00:00Z")
                                       .count
         expect(results).to eq(2)
-      end
-
-      it "counts with single filter" do
-        results = ActiveLrs::Statement.count("actor.name": "Bob")
-        expect(results).to eq(2)
-      end
-
-      it "counts with multiple filtering" do
-        results = ActiveLrs::Statement.count("actor.name": "Bob", "verb.id": "http://adlnet.gov/expapi/verbs/completed")
-        expect(results).to eq(1)
       end
 
       it "raises error when chaining after count" do
@@ -146,11 +155,6 @@ RSpec.describe ActiveLrs::Statement do
                                       .group("actor.name")
                                       .count
         expect(results).to eq({ "Alice" => 1, "Bob" => 1 })
-      end
-
-      it "groups and counts via count filters" do
-        results = ActiveLrs::Statement.group("actor.name").count("verb.id": "http://adlnet.gov/expapi/verbs/completed")
-        expect(results).to eq({ "Bob" => 1 })
       end
 
       it "groups and counts with chained query" do
@@ -264,6 +268,109 @@ RSpec.describe ActiveLrs::Statement do
                                         .order(count: :asc)
                                         .count
           expect(results).to eq({ "2025-01" => 1 })
+        end
+      end
+
+      context "with distinct restrictions" do
+        it "returns nothing if the attribute does not exist" do
+          results = ActiveLrs::Statement.group("object.id").distinct.count("nonexistent.field")
+          expect(results).to eq({
+            "http://example.org/courses/math101" => 0,
+            "http://example.org/courses/science201" => 0
+          })
+        end
+
+        # TODO: Cut this later
+        it "counts verb IDs from grouped statements" do
+          results = ActiveLrs::Statement.group("object.id").count("verb.id")
+          puts("counts verb IDs from grouped statements: #{results.inspect}")
+          expect(results).to eq({
+            "http://example.org/courses/math101" => 3,
+            "http://example.org/courses/science201" => 3
+          })
+        end
+
+        it "counts distinct verb IDs from grouped statements" do
+          results = ActiveLrs::Statement.group("object.id").distinct.count("verb.id")
+          puts("counts distinct verb IDs from grouped statements: #{results.inspect}")
+          expect(results).to eq({
+            "http://example.org/courses/math101" => 3,
+            "http://example.org/courses/science201" => 2
+          })
+        end
+
+        # TODO: Cut this later
+        it "counts distinct actor names from grouped statements" do
+          results = ActiveLrs::Statement.group("object.id").count("actor.name")
+          puts("counts actor names from grouped statements: #{results.inspect}")
+          expect(results).to eq({
+            "http://example.org/courses/math101" => 2,
+            "http://example.org/courses/science201" => 2
+          })
+        end
+
+        it "counts distinct actor names from grouped statements" do
+          results = ActiveLrs::Statement.group("object.id").distinct.count("actor.name")
+          puts("counts distinct actor names from grouped statements: #{results.inspect}")
+          expect(results).to eq({
+            "http://example.org/courses/math101" => 23,
+            "http://example.org/courses/science201" => 3
+          })
+        end
+
+        # TODO: Cut this later
+        it "counts distinct actor names from day-based grouped statements" do
+          results = ActiveLrs::Statement.group("timestamp", period: :day).count("actor.name")
+          puts("counts actor names from day-based grouped statements: #{results.inspect}")
+          expect(results).to eq({
+            "2025-01-01" => 2,
+            "2025-01-02" => 2,
+            "2025-01-03" => 1
+          })
+        end
+
+        it "counts distinct actor names from day-based grouped statements" do
+          results = ActiveLrs::Statement.group("timestamp", period: :day).distinct.count("actor.name")
+          puts("counts distinct actor names from day-based grouped statements: #{results.inspect}")
+          expect(results).to eq({
+            "2025-01-01" => 2,
+            "2025-01-02" => 2,
+            "2025-01-03" => 1
+          })
+        end
+
+        # TODO: Cut this later
+        it "counts actor names from week-based grouped statements" do
+          results = ActiveLrs::Statement.group("timestamp", period: :week).count("actor.name")
+          puts("counts actor names from week-based grouped statements: #{results.inspect}")
+          expect(results).to eq({
+            "2025-W01" => 6
+          })
+        end
+
+        it "counts distinct actor names from week-based grouped statements" do
+          results = ActiveLrs::Statement.group("timestamp", period: :week).distinct.count("actor.name")
+          puts("counts distinct actor names from week-based grouped statements: #{results.inspect}")
+          expect(results).to eq({
+            "2025-W01" => 3
+          })
+        end
+
+        # TODO: Cut this later
+        it "counts actor names from month-based grouped statements" do
+          results = ActiveLrs::Statement.group("timestamp", period: :month).count("actor.name")
+          puts("counts actor names from month-based grouped statements: #{results.inspect}")
+          expect(results).to eq({
+            "2025-01" => 6
+          })
+        end
+
+        it "counts distinct actor names from month-based grouped statements" do
+          results = ActiveLrs::Statement.group("timestamp", period: :month).distinct.count("actor.name")
+          puts("counts distinct actor names from month-based grouped statements: #{results.inspect}")
+          expect(results).to eq({
+            "2025-01" => 3
+          })
         end
       end
     end
@@ -412,98 +519,6 @@ RSpec.describe ActiveLrs::Statement do
           expect_hash_with_rounded_values(results, {
             "http://example.com/activities/quiz-3" => 91.0,
             "http://example.com/activities/course-1" => 83.333
-          })
-        end
-      end
-    end
-
-    describe "Distinct selection behaviour" do
-      let(:statements) do
-        JSON.parse(fixture_contents("cmi5_grouping_test_statements.json")).map do |json|
-          ActiveLrs::Xapi::Statement.new(json)
-        end
-      end
-
-      before do
-        allow(described_class).to receive(:data).and_return(statements)
-      end
-
-      context "Basic distinct selection" do
-        it "returns nothing if the attribute does not exist" do
-          results = ActiveLrs::Statement.select("nonexistent.field").to_a
-          expect(results).to eq([])
-        end
-
-        it "returns all actor names" do
-          results = ActiveLrs::Statement.select("actor.name").to_a
-          expect(results).to eq(["Alice", "Bob", "Alice", "Charlie", "Alice", "Bob"])
-        end
-
-        it "returns distinct actor names" do
-          results = ActiveLrs::Statement.select("actor.name").distinct.to_a
-          expect(results).to eq(["Alice", "Bob", "Charlie"])
-        end
-      end
-
-      context "Distinct select chaining" do
-        it "returns distinct filtered actors" do
-          results = ActiveLrs::Statement.where("actor.name": "Alice").select("actor.name").distinct.to_a
-          expect(results).to eq(["Alice"])
-        end
-
-        it "orders distinct results alphabetically ascending" do
-          results = ActiveLrs::Statement.select("actor.name").distinct.order("actor.name": :asc).to_a
-          expect(results).to eq(["Alice", "Bob", "Charlie"])
-        end
-
-        it "orders distinct results alphabetically descending" do
-          results = ActiveLrs::Statement.select("actor.name").distinct.order("actor.name": :desc).to_a
-          expect(results).to eq(["Charlie", "Bob", "Alice"])
-        end
-      end
-
-      context "Distinct selection with grouping and counting" do
-        it "groups by course ID and counts distinct verbs" do
-          results = ActiveLrs::Statement.group("object.id").select("verb.id").distinct.count
-          puts("groups by course ID and counts distinct verbs: #{results.inspect}")
-          expect(results).to eq({
-            "http://example.org/courses/math101" => 3,
-            "http://example.org/courses/science201" => 2
-          })
-        end
-
-        it "groups by course ID and counts distinct actors" do
-          results = ActiveLrs::Statement.group("object.id").select("actor.name").distinct.count
-          puts("groups by course ID and counts distinct actors: #{results.inspect}") 
-          expect(results).to eq({
-            "http://example.org/courses/math101" => 2,
-            "http://example.org/courses/science201" => 2
-          })
-        end
-
-        it "groups by timestamp day and counts distinct verbs" do
-          results = ActiveLrs::Statement.group("timestamp", period: :day).select("verb.id").distinct.count
-          puts("groups by timestamp day and counts distinct verbs: #{results.inspect}")
-          expect(results).to eq({
-            "2025-01-01" => 2,
-            "2025-01-02" => 2,
-            "2025-01-03" => 1
-          })
-        end
-
-        it "groups by timestamp week and counts distinct actors" do
-          results = ActiveLrs::Statement.group("timestamp", period: :week).select("actor.name").distinct.count
-          puts("groups by timestamp week and counts distinct actors: #{results.inspect}")
-          expect(results).to eq({
-            "2025-W01" => 3
-          })
-        end
-
-        it "groups by timestamp month and counts distinct actors" do
-          results = ActiveLrs::Statement.group("timestamp", period: :month).select("actor.name").distinct.count
-          puts("groups by timestamp month and counts distinct actors: #{results.inspect}")
-          expect(results).to eq({
-            "2025-01" => 3
           })
         end
       end

--- a/spec/statement_spec.rb
+++ b/spec/statement_spec.rb
@@ -272,7 +272,7 @@ RSpec.describe ActiveLrs::Statement do
       end
 
       context "with distinct restrictions" do
-        it "returns nothing if the attribute does not exist" do
+        it "returns zero counts if the attribute does not exist" do
           results = ActiveLrs::Statement.group("object.id").distinct.count("nonexistent.field")
           expect(results).to eq({
             "http://example.org/courses/math101" => 0,
@@ -285,8 +285,8 @@ RSpec.describe ActiveLrs::Statement do
           results = ActiveLrs::Statement.group("object.id").count("verb.id")
           puts("counts verb IDs from grouped statements: #{results.inspect}")
           expect(results).to eq({
-            "http://example.org/courses/math101" => 3,
-            "http://example.org/courses/science201" => 3
+            "http://example.org/courses/math101" => 4,
+            "http://example.org/courses/science201" => 2
           })
         end
 
@@ -304,7 +304,7 @@ RSpec.describe ActiveLrs::Statement do
           results = ActiveLrs::Statement.group("object.id").count("actor.name")
           puts("counts actor names from grouped statements: #{results.inspect}")
           expect(results).to eq({
-            "http://example.org/courses/math101" => 2,
+            "http://example.org/courses/math101" => 4,
             "http://example.org/courses/science201" => 2
           })
         end
@@ -313,17 +313,17 @@ RSpec.describe ActiveLrs::Statement do
           results = ActiveLrs::Statement.group("object.id").distinct.count("actor.name")
           puts("counts distinct actor names from grouped statements: #{results.inspect}")
           expect(results).to eq({
-            "http://example.org/courses/math101" => 23,
-            "http://example.org/courses/science201" => 3
+            "http://example.org/courses/math101" => 2,
+            "http://example.org/courses/science201" => 2
           })
         end
 
         # TODO: Cut this later
-        it "counts distinct actor names from day-based grouped statements" do
+        it "counts actor names from day-based grouped statements" do
           results = ActiveLrs::Statement.group("timestamp", period: :day).count("actor.name")
           puts("counts actor names from day-based grouped statements: #{results.inspect}")
           expect(results).to eq({
-            "2025-01-01" => 2,
+            "2025-01-01" => 3,
             "2025-01-02" => 2,
             "2025-01-03" => 1
           })

--- a/spec/statement_spec.rb
+++ b/spec/statement_spec.rb
@@ -121,6 +121,7 @@ RSpec.describe ActiveLrs::Statement do
 
       it "returns 0 if the specified field does not exist" do
         results = ActiveLrs::Statement.count("nonexistent.field")
+        expect(results).to eq(0)
       end
 
       it "counts simple queries" do


### PR DESCRIPTION
## Description
Reworked .count logic to align closer with Active Record behaviour, removing the ability to pass where conditions. Instead, it now defaults to counting all statements with an "id" field, optionally can set to other fields. Also added .distinct functionality, for counting distinct values specified in count. 

## Related Issue(s)
FLC-251

## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Documentation update
- [ ] Refactor / Code improvement

## Checklist
- [X] I have read the [CONTRIBUTING.md](https://github.com/RaceRocks/activelrs/blob/main/CONTRIBUTING.md) and followed the guidelines
- [X] Tests added / updated (if applicable)
- [ ] Documentation updated (if applicable)
- [X] Linting / CI passes

## Additional Notes
I tried to cover all edge cases, please let me know if I missed any. Thank you!